### PR TITLE
deploy-contract: allow defining custom docker args

### DIFF
--- a/script/deploy-contract
+++ b/script/deploy-contract
@@ -20,6 +20,7 @@ INITIAL_STORAGE=`envsubst < contracts/${CONTRACT}.storage`
 echo "targeting node: $NODE_URL"
 docker run \
     -v "$PWD/contracts/${CONTRACT}.tz":/tmp/contract.tz \
+    ${DOCKER_ARGS:-} \
     --entrypoint /bin/sh \
     tezos/tezos:latest \
     -c "


### PR DESCRIPTION
This allows setting an additional docker arg, eg: `DOCKER_ARGS=--network=host ./script/deploy-contract`